### PR TITLE
Added the file descriptor set library (Cygwin bug)

### DIFF
--- a/core/Event_Handler.hh
+++ b/core/Event_Handler.hh
@@ -9,6 +9,7 @@
 #define EVENT_HANDLER_HH
 
 #include "Types.h"
+#include <sys/select.h>
 
 /**
 * The definitions in this header file are needed for TITAN.


### PR DESCRIPTION
As explained in this thread: https://www.eclipse.org/forums/index.php/t/1075026/
On certain Cygwin configuration, it's impossible to compile without this line.